### PR TITLE
fix: add missing comma in install_requires section

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setuptools.setup(
     ],
     python_requires='>=3.5',
     install_requires=[
-        "future-fstrings>=1.2"
-        "db-sync-tool-kmi>=2.9.0",
+        "future-fstrings>=1.2",
+        "db-sync-tool-kmi>=2.9.0"
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Currently the install_requires section is actually invalid. Starting with pip 24.1, packages with invalid requirements can not be processed. So with pip 24.1 its no longer installable without that fix.